### PR TITLE
Fixing parameter units in comment

### DIFF
--- a/lib/logstash/inputs/meetup.rb
+++ b/lib/logstash/inputs/meetup.rb
@@ -27,7 +27,7 @@ class LogStash::Inputs::Meetup < LogStash::Inputs::Base
   # Must have one of `urlname`, `venueid`, `groupid`
   config :groupid, :validate => :string
 
-  # Interval to run the command. Value is in seconds.
+  # Interval to run the command. Value is in minutes.
   config :interval, :validate => :number, :required => true
 
   # Meetup Key


### PR DESCRIPTION
I'm pretty sure the units for `@interval` should be minutes, not seconds, based on reading the code for [`Stud.interval`](https://github.com/jordansissel/ruby-stud/blob/master/lib/stud/interval.rb) and the fact that this plugin [multiplies by 60](https://github.com/logstash-plugins/logstash-input-meetup/blob/master/lib/logstash/inputs/meetup.rb#L61) before calling `Stud.interval`.
